### PR TITLE
fix: Change "Happy, Safe" to "Happy, At Peace"

### DIFF
--- a/mc/model.py
+++ b/mc/model.py
@@ -725,7 +725,7 @@ def populate_db_with_setup_data() -> None:
         mc.mc_global.BreathingPhraseType.in_out
     )
     PhrasesM.add(
-        "Happy, Safe",
+        "Happy, At Peace",
         "May I be happy",
         "May I be peaceful",
         "happy",
@@ -741,7 +741,7 @@ def populate_db_with_setup_data() -> None:
         mc.mc_global.BreathingPhraseType.in_out
     )
 
-    """    
+    """
     PhrasesM.add(
         "Compassion",
         "Breathing in compassion to myself",


### PR DESCRIPTION
Changed breathing phrase option name to  “Happy, At Peace” instead of
“Happy, Safe” to match option’s final display of “may I be happy” and
“may I be peaceful” as suggested and approved in the forum.